### PR TITLE
feat: add deepseek support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,27 @@ docker-compose up -d
 5. Press on `Use alternative compute backend`
 6. Enter the compute backend url (e.g. `https://my-alternative-compute-backend.domain.com`)
 7. Press on `Add the alternative backend model`
+
+### Deepseek models
+
+For deepseek models, you have to remove the `<think>.*</think>` part from the chat response. If you stream the response, you have to ignore the text between and including `<think>` and `</think>` tags. \
+This is already done for groq models but not for your very own remote models.
+
+Here is an example in JavaScript:
+```javascript
+const response = "<think>Some text</think>Some other text";
+const cleanedResponse = response.replace(/<think>.*?<\/think>/gs, "");
+console.log(cleanedResponse); // Some other text
+
+/// OR With streaming ///
+
+let thinking = true;
+
+// Stream the response
+// delta is the response from the model delta
+if (thinking) {
+  if (choice.delta.content.includes('</think>'))
+    thinking = false;
+  return;
+}
+```

--- a/api/src/utils/generation.ts
+++ b/api/src/utils/generation.ts
@@ -207,6 +207,7 @@ export class Generation {
     });
     res.flushHeaders();
     let buffer = '';
+    let thinking = model.name.includes('deepseek');
     child.data.on('data', (data) => {
       if (Object.values(Providers).includes(model.name.split('-')[0] as Providers)) {
         buffer += data.toString();
@@ -221,6 +222,11 @@ export class Generation {
               JSON.parse(result).choices.forEach((choice: any) => {
                 if (choice.delta.content == undefined)
                   return;
+                if (thinking) {
+                  if (choice.delta.content.includes('</think>'))
+                    thinking = false;
+                  return;
+                }
                 response += choice.delta.content;
                 res.write(choice.delta.content);
                 res.flushHeaders();


### PR DESCRIPTION
## Description
This pull request includes updates to handle the removal of `<think>` tags from responses generated by deepseek models, both in the documentation and in the code handling the response streaming. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R125): Added a section explaining how to handle `<think>` tags in deepseek model responses, including a JavaScript example for removing these tags from the response.

Code updates:

* [`api/src/utils/generation.ts`](diffhunk://#diff-5c09e21e9a347ef69db7d944f11a991d87425f0f4488543742fb9cfd1d8c35ddR210): Added logic to check for deepseek models and handle the removal of `<think>` tags during response streaming. This includes setting a `thinking` flag based on the model name and updating the response processing to skip content within `<think>` tags. [[1]](diffhunk://#diff-5c09e21e9a347ef69db7d944f11a991d87425f0f4488543742fb9cfd1d8c35ddR210) [[2]](diffhunk://#diff-5c09e21e9a347ef69db7d944f11a991d87425f0f4488543742fb9cfd1d8c35ddR225-R229)
