### PR TITLE
make: name OCI image correctly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,8 @@ jobs:
         run: pnpm run build
       - name: Build and push
         run: |
-          docker buildx build . --tag ghcr.io/ungarscool1/llama-web:client --platform linux/amd64,linux/arm64 --push
+          docker buildx build . --tags ghcr.io/ungarscool1/llama-web/client:${{ github.event.release.tag_name }},ghcr.io/ungarscool1/llama-web/client:latest --platform linux/amd64,linux/arm64 --push
+
   api:
     runs-on: ubuntu-latest
     defaults:
@@ -50,14 +51,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to GHCR
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -65,4 +63,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: |
-          docker buildx build . --tag ghcr.io/ungarscool1/llama-web:api --platform linux/amd64,linux/arm64 --push
+          docker buildx build . --tags ghcr.io/ungarscool1/llama-web/api:${{ github.event.release.tag_name }},ghcr.io/ungarscool1/llama-web/api:latest --platform linux/amd64,linux/arm64 --push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm run build
       - name: Build and push
         run: |
-          docker buildx build . --tags ghcr.io/ungarscool1/llama-web/client:${{ github.event.release.tag_name }},ghcr.io/ungarscool1/llama-web/client:latest --platform linux/amd64,linux/arm64 --push
+          docker buildx build . -t ghcr.io/ungarscool1/llama-web/client:${{ github.event.release.tag_name }} -t ghcr.io/ungarscool1/llama-web/client:latest --platform linux/amd64,linux/arm64 --push
 
   api:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,4 +63,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: |
-          docker buildx build . --tags ghcr.io/ungarscool1/llama-web/api:${{ github.event.release.tag_name }},ghcr.io/ungarscool1/llama-web/api:latest --platform linux/amd64,linux/arm64 --push
+          docker buildx build . -t ghcr.io/ungarscool1/llama-web/api:${{ github.event.release.tag_name }} -t ghcr.io/ungarscool1/llama-web/api:latest --platform linux/amd64,linux/arm64 --push


### PR DESCRIPTION
## Description
This pull request focuses on updating the GitHub Actions workflow for releases to improve the tagging and setup process for Docker images.

Improvements to Docker image tagging and setup:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL42-R43): Updated the `docker buildx build` command to include both the specific release tag and the `latest` tag for the `client` Docker image.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL53-R66): Updated the `docker buildx build` command to include both the specific release tag and the `latest` tag for the `api` Docker image.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL53-R66): Consolidated the setup steps for QEMU, Docker Buildx, and GHCR login by removing unnecessary blank lines and aligning the naming conventions.

Closes #74
