### PR TITLE
make: remove hardcoded values

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,8 +87,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Merge manifests
         run: |
-          amd_digest=$(docker manifest inspect ghcr.io/ungarscool1/llama-web-ci-test/client:latest-amd64 | jq '.manifests[] | select(.platform.architecture == "amd64") | .digest' -r)
-          arm_digest=$(docker manifest inspect ghcr.io/ungarscool1/llama-web-ci-test/client:latest-arm64 | jq '.manifests[] | select(.platform.architecture == "arm64") | .digest' -r)
+          amd_digest=$(docker manifest inspect ghcr.io/${{ github.repository }}/client:latest-amd64 | jq '.manifests[] | select(.platform.architecture == "amd64") | .digest' -r)
+          arm_digest=$(docker manifest inspect ghcr.io/${{ github.repository }}/client:latest-arm64 | jq '.manifests[] | select(.platform.architecture == "arm64") | .digest' -r)
           echo "AMD Digest: $amd_digest"
           echo "ARM Digest: $arm_digest"
           docker manifest create ghcr.io/${{ github.repository }}/client:latest \
@@ -161,8 +161,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Merge manifests
         run: |
-          amd_digest=$(docker manifest inspect ghcr.io/ungarscool1/llama-web-ci-test/api:latest-amd64 | jq '.manifests[] | select(.platform.architecture == "amd64") | .digest' -r)
-          arm_digest=$(docker manifest inspect ghcr.io/ungarscool1/llama-web-ci-test/api:latest-arm64 | jq '.manifests[] | select(.platform.architecture == "arm64") | .digest' -r)
+          amd_digest=$(docker manifest inspect ghcr.io/${{ github.repository }}/api:latest-amd64 | jq '.manifests[] | select(.platform.architecture == "amd64") | .digest' -r)
+          arm_digest=$(docker manifest inspect ghcr.io/${{ github.repository }}/api:latest-arm64 | jq '.manifests[] | select(.platform.architecture == "arm64") | .digest' -r)
           echo "AMD Digest: $amd_digest"
           echo "ARM Digest: $arm_digest"
           docker manifest create ghcr.io/${{ github.repository }}/api:latest \


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yaml` file to make the Docker image repository references dynamic based on the GitHub repository name. This will improve the flexibility and maintainability of the workflow.

Improvements to workflow flexibility:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL90-R91): Updated the Docker image repository references to use `${{ github.repository }}` instead of hardcoding the repository name for the client images.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL164-R165): Updated the Docker image repository references to use `${{ github.repository }}` instead of hardcoding the repository name for the API images.